### PR TITLE
Ignore Keychron Q1 Pro firmware directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ quantum/version.h
 *.hex
 *.qmk
 *.uf2
+keyboards/keychron/q1_pro/firmware/
 
 # DD config at wrong location
 /keyboards/**/keymaps/*/info.json

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -22,6 +22,7 @@
 - Clarified branch workflow and emphasis on concise updates.
 - Submodules updated for Q1 Pro work.
 - Removed unsupported encoder_map feature from Q1 Pro and tidied layout macros.
+- Removed stray firmware directory from Keychron Q1 Pro and added ignore rule.
 
 # QMK Keyboard Development Guidelines
 


### PR DESCRIPTION
## Summary
- ignore accidental firmware artifacts for Keychron Q1 Pro
- document change in project task notes

## Testing
- `qmk lint -kb keychron/q1_pro`


------
https://chatgpt.com/codex/tasks/task_e_68a2558cb50c83248573a6205cdf4093