### PR TITLE
Enable VIA for Keychron Q1 Pro

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -22,6 +22,7 @@
 - Clarified branch workflow and emphasis on concise updates.
 - Submodules updated for Q1 Pro work.
 - Removed unsupported encoder_map feature from Q1 Pro and tidied layout macros.
+- Enabled VIA on Q1 Pro; lint still failing due to keyboard.json location.
 
 # QMK Keyboard Development Guidelines
 

--- a/keyboards/keychron/q1_pro/rules.mk
+++ b/keyboards/keychron/q1_pro/rules.mk
@@ -7,3 +7,5 @@ BLUETOOTH_DRIVER = custom
 DEBOUNCE_TYPE = custom
 
 include keyboards/keychron/common/common.mk
+
+VIA_ENABLE = yes


### PR DESCRIPTION
## Summary
- enable VIA support in `keychron/q1_pro` rules
- document VIA addition in CRUSH notes

## Testing
- `qmk lint -kb keychron/q1_pro/ansi_knob` (fails: Invalid keyboard.json location, keymap via should not exist)
- `qmk compile -kb keychron/q1_pro/ansi_knob -km via` (fails: Invalid keyboard.json location)


------
https://chatgpt.com/codex/tasks/task_e_68a255a68db48324ad3b45e80367e012