### PR TITLE
docs: note submodule update before build

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -218,3 +218,4 @@ typedef struct {
 - work: Renode not installed by default; apt-get install renode needed for CI job.
 - work: pytest still fails due to missing ORIG_CWD environment variable.
 - work: apt-get update hit 403 for mise.jdx.dev; renode package unavailable via apt, installed gcc-arm-none-eabi.
+- work: git submodule update --init --recursive required before compiling to fetch dependencies.


### PR DESCRIPTION
## Summary
- document running `git submodule update --init --recursive` before compiling
- initialize project submodules to provide required sources

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68aa394199b88324bbe62086bc81adc9