### PR TITLE
feat(renode): log invalid matrix coordinates

### DIFF
--- a/util/renode/keychron_q1_pro.repl
+++ b/util/renode/keychron_q1_pro.repl
@@ -40,12 +40,14 @@ matrix: Python.Matrix @ none
     filename: @matrix.py
     rows: 6
     cols: 16
+    # Row lines read by the MCU
     [0] -> gpioPortB@5
     [1] -> gpioPortB@4
     [2] -> gpioPortB@3
     [3] -> gpioPortA@15
     [4] -> gpioPortA@14
     [5] -> gpioPortA@13
+    # Shift-register control lines for column selection
     gpioPortA@7 -> matrix@ds
     gpioPortA@1 -> matrix@shcp
     gpioPortB@0 -> matrix@stcp

--- a/util/renode/matrix.py
+++ b/util/renode/matrix.py
@@ -68,9 +68,13 @@ class Matrix(IManagedGPIOReceiver, IProvidesGPIO):
         if 0 <= row < self.rows and 0 <= col < self.cols:
             self.keys[row][col] = True
             self._update_rows()
+        else:
+            Log.warning(f"press: invalid key ({row}, {col})")
 
     @export
     def release(self, row: int, col: int):
         if 0 <= row < self.rows and 0 <= col < self.cols:
             self.keys[row][col] = False
             self._update_rows()
+        else:
+            Log.warning(f"release: invalid key ({row}, {col})")


### PR DESCRIPTION
## Summary
- add warnings for invalid matrix press/release coordinates
- document Keychron Q1 Pro row lines and shift-register controls in Renode platform

## Testing
- `qmk lint -kb keychron/q1_pro`
- `qmk compile -kb keychron/q1_pro -km default` *(fails: RGB_MATRIX_LED_COUNT undeclared, eeconfig_read_keymap signature)*
- `renode -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aacc03d2008324bb4831e726d27073