### PR TITLE
Add Renode testing docs and CI workflow

### DIFF
--- a/.github/workflows/renode-test.yml
+++ b/.github/workflows/renode-test.yml
@@ -1,0 +1,47 @@
+---
+name: Renode Test
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    paths:
+      - 'keyboards/keychron/q1_pro/**'
+      - '.github/workflows/renode-test.yml'
+  pull_request:
+    paths:
+      - 'keyboards/keychron/q1_pro/**'
+      - '.github/workflows/renode-test.yml'
+
+jobs:
+  renode:
+    runs-on: ubuntu-latest
+    container: ghcr.io/qmk/qmk_cli
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends renode
+
+      - name: Build and run Renode
+        run: |
+          set -o pipefail
+          RENODE_ARGS="--disable-xwt \
+          -e 'sysbus.usart2 DumpUartLog uart.log' \
+          -e 'emulation RunFor \"1\"' \
+          -e 'quit'" \
+          make keychron/q1_pro:renode
+
+      - name: Verify UART output
+        run: |
+          grep -qi 'QMK Firmware' uart.log
+          grep -qi 'matrix init' uart.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS Instructions
 - Use `CRUSH.md` to record missing packages, dependencies, or process improvements encountered during tasks.
-- Any task note added must begin with the current branch name. For example:
+- Each task note in `CRUSH.md` must begin with the current branch name. For example:
   - `feature/renode: describe task`
 - See `CRUSH.md` for further instructions.

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -219,3 +219,4 @@ typedef struct {
 - work: pytest still fails due to missing ORIG_CWD environment variable.
 - work: apt-get update hit 403 for mise.jdx.dev; renode package unavailable via apt, installed gcc-arm-none-eabi.
 - work: git submodule update --init --recursive required before compiling to fetch dependencies.
+- work: yamllint installed; renode package unavailable via apt-get, and `make keychron/q1_pro:renode` fails (`RGB_MATRIX_LED_COUNT` undeclared, `eeconfig_read_keymap` signature mismatch).

--- a/keyboards/keychron/q1_pro/readme.md
+++ b/keyboards/keychron/q1_pro/readme.md
@@ -22,15 +22,15 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 ## Renode Virtual Testing
 
-Renode 1.15 or newer can emulate the Q1 Pro so you can test keymaps without hardware.
+Renode 1.15 or later can emulate the Q1 Pro, allowing you to exercise keymaps without physical hardware.
 
-1. Install Renode ≥1.15 (see [Renode Setup](../../../docs/renode_setup.md) for OS-specific installation steps).
-2. From the repository root, build the firmware and launch Renode:
+1. Install Renode 1.15 or newer (see [Renode Setup](../../../docs/renode_setup.md) for OS-specific instructions).
+2. From the repository root, build the Renode target and launch the emulator:
 
     ```sh
     make keychron/q1_pro:renode
     ```
-3. At the Renode monitor, use the `matrix` peripheral to simulate key presses. For example, to press and release the *Esc* key:
+3. At the Renode monitor, issue `matrix` commands to simulate key presses. For example, to press and release *Esc*:
 
     ```text
     matrix press 0 0


### PR DESCRIPTION
## Summary
- document Renode virtual testing for Keychron Q1 Pro
- run Renode simulation in CI and check boot/matrix UART output
- clarify AGENTS instructions on prefixing task notes with branch name

## Testing
- `yamllint .github/workflows/renode-test.yml`
- `make keychron/q1_pro:renode` *(fails: RGB_MATRIX_LED_COUNT undeclared, eeconfig_read_keymap signature mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68aace1f4b5483248cae216e470136a4