### PR TITLE
Quote on key in renode test workflow

### DIFF
--- a/.github/workflows/renode-test.yml
+++ b/.github/workflows/renode-test.yml
@@ -4,7 +4,7 @@ name: Renode Test
 permissions:
   contents: read
 
-on:
+'on':
   push:
     branches:
       - master

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -220,3 +220,4 @@ typedef struct {
 - work: apt-get update hit 403 for mise.jdx.dev; renode package unavailable via apt, installed gcc-arm-none-eabi.
 - work: git submodule update --init --recursive required before compiling to fetch dependencies.
 - work: yamllint installed; renode package unavailable via apt-get, and `make keychron/q1_pro:renode` fails (`RGB_MATRIX_LED_COUNT` undeclared, `eeconfig_read_keymap` signature mismatch).
+- work: yamllint missing; installed via pip to run workflow linter.


### PR DESCRIPTION
## Summary
- quote the top-level `on` key in the Renode test workflow to avoid truthy interpretation
- log missing yamllint dependency

## Testing
- `yamllint .github/workflows/renode-test.yml`


------
https://chatgpt.com/codex/tasks/task_e_68aad12400048324b365071f0ca1267c