### PR TITLE
ci: document Docker and add run-act script

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -54,3 +54,4 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: verified Renode command existence and allowed path override via RENODE.
 - work: ensured run-renode script checks for renode command and supports RENODE override.
 - work: updated TinyGo CI to use acifani/setup-tinygo@v2 and actions/upload-artifact@v4.
+- go/feature-ci-act: documented Docker/act usage and added run-act script verifying artifacts.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,43 @@
+# Continuous Integration
+
+This guide explains how to run the TinyGo/Renode CI workflow locally.
+
+## Install Docker
+
+Docker is required for running GitHub Actions locally. On Debian/Ubuntu:
+
+```sh
+sudo apt-get update
+sudo apt-get install --yes docker.io
+sudo systemctl start docker
+sudo usermod -aG docker "$USER"
+# Log out and back in so group changes take effect
+```
+
+Verify that Docker is available:
+
+```sh
+docker info
+```
+
+## Install `act`
+
+[`act`](https://github.com/nektos/act) executes GitHub Actions workflows locally.
+Install it using your package manager or the project's install script. On Debian/Ubuntu:
+
+```sh
+curl -L https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+```
+
+## Run the workflow
+
+From the repository root, execute:
+
+```sh
+act -W .github/workflows/tinygo-renode.yml -j build
+```
+
+This runs the `build` job defined in `.github/workflows/tinygo-renode.yml`.
+The `scripts/run-act.sh` helper script checks that the Docker daemon is
+running, executes the workflow with a suitable image, and verifies that
+`hid.log` and `build/firmware.elf` are produced.

--- a/scripts/run-act.sh
+++ b/scripts/run-act.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon is not reachable. Please start Docker." >&2
+  exit 1
+fi
+
+act -W .github/workflows/tinygo-renode.yml -j build -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:full-22.04
+
+if [[ ! -f hid.log || ! -f build/firmware.elf ]]; then
+  echo "Expected artifacts hid.log and build/firmware.elf were not produced." >&2
+  exit 1
+fi
+
+echo "Workflow completed and required artifacts are present."


### PR DESCRIPTION
## Summary
- document Docker and act usage for TinyGo/Renode workflow
- add run-act helper script verifying Docker and expected artifacts

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aad1d4938c8324ba943e23a1f3b169