### PR TITLE
ci: use qmk docs build command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ defaults:
 jobs:
   generate:
     runs-on: ubuntu-latest
-    container: ghcr.io/qmk/qmk_cli
+    container: ghcr.io/qmk/qmk_cli:latest
 
     steps:
     - uses: actions/checkout@v4
@@ -37,6 +37,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update && apt-get install -y rsync doxygen
+        pip install --upgrade qmk
         # install nvm
         touch $HOME/.bashrc
         wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
@@ -52,7 +53,7 @@ jobs:
       run: |
         source $HOME/.bashrc
         nvm use 20
-        qmk --verbose generate-docs
+        qmk docs --build
 
     - name: Deploy
       if: ${{ github.event_name == 'push' && github.repository == 'qmk/qmk_firmware' }}

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -55,3 +55,4 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: ensured run-renode script checks for renode command and supports RENODE override.
 - work: updated TinyGo CI to use acifani/setup-tinygo@v2 and actions/upload-artifact@v4.
 - go/feature-ci-act: documented Docker/act usage and added run-act script verifying artifacts.
+- work: updated docs workflow to use qmk docs build command.


### PR DESCRIPTION
## Summary
- generate docs using `qmk docs --build`
- install latest qmk CLI in docs workflow
- record docs workflow update in CRUSH notes

## Testing
- `go fmt ./...`
- `go test ./...`
- `qmk generate-docs` (official repo)

------
https://chatgpt.com/codex/tasks/task_e_68aad3fc0dfc8324b45c715a5ac38d5c