### PR TITLE
Install portable Renode build in CI

### DIFF
--- a/.github/workflows/tinygo-renode.yml
+++ b/.github/workflows/tinygo-renode.yml
@@ -22,9 +22,7 @@ jobs:
         with:
           tinygo-version: 0.28.1
       - name: Install Renode
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y renode
+        run: scripts/install-renode.sh
       - name: Run Renode simulation
         run: |
           RENODE_LOG=hid.log scripts/run-renode.sh

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -56,3 +56,4 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: updated TinyGo CI to use acifani/setup-tinygo@v2 and actions/upload-artifact@v4.
 - go/feature-ci-act: documented Docker/act usage and added run-act script verifying artifacts.
 - work: updated docs workflow to use qmk docs build command.
+- go/feature-renode-install: added script to install Renode portable build and updated CI workflow.

--- a/docs/renode.md
+++ b/docs/renode.md
@@ -1,0 +1,35 @@
+# Renode Installation
+
+Renode can be installed either automatically using the provided script or manually by downloading a portable build.
+
+## Using the install script
+
+Run the helper script from the repository root:
+
+```bash
+scripts/install-renode.sh
+```
+
+The script downloads the latest portable build from [builds.renode.io](https://builds.renode.io/), extracts it to `~/renode`, and makes the `renode` binary available on your `PATH`. When used in GitHub Actions, the script updates `GITHUB_PATH` so subsequent steps can invoke `renode`.
+
+## Manual installation
+
+1. Download the latest portable build:
+   ```bash
+   curl -LO https://builds.renode.io/renode-latest.linux-portable.tar.gz
+   ```
+2. Extract the archive to a directory:
+   ```bash
+   mkdir -p $HOME/renode
+   tar -xzf renode-latest.linux-portable.tar.gz -C $HOME/renode --strip-components=1
+   ```
+3. Add the directory to your `PATH`:
+   ```bash
+   export PATH="$HOME/renode:$PATH"
+   ```
+4. Verify the installation:
+   ```bash
+   renode --version
+   ```
+
+This will make the `renode` command available for running simulations.

--- a/scripts/install-renode.sh
+++ b/scripts/install-renode.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+RENODE_URL="https://builds.renode.io/renode-latest.linux-portable.tar.gz"
+INSTALL_DIR="${RENODE_INSTALL_DIR:-$HOME/renode}"
+
+mkdir -p "$INSTALL_DIR"
+curl -L "$RENODE_URL" | tar -xz -C "$INSTALL_DIR" --strip-components=1
+
+# Make renode available on PATH
+if [ -n "${GITHUB_PATH:-}" ]; then
+  echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+fi
+export PATH="$INSTALL_DIR:$PATH"
+
+echo "Renode installed to $INSTALL_DIR"


### PR DESCRIPTION
## Summary
- add script to download portable Renode build and expose binary on PATH
- switch TinyGo workflow to use portable installer instead of apt package
- document Renode installation and script usage

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aad702b5dc8324adfc6a94c93e0ca5