### PR TITLE
ci: permit labeler workflow to manage labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,15 @@
+---
 name: "Pull Request Labeler"
 
-on:
-- pull_request_target
+'on':
+  - pull_request_target
 
 jobs:
   triage:
     permissions:
       contents: read
       pull-requests: write
+      labels: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+      - uses: actions/labeler@v5

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -223,3 +223,5 @@ typedef struct {
 - work: yamllint missing; installed via pip to run workflow linter.
 - work: qmk lint passes but qmk compile and `make keychron/q1_pro:renode` fail (`LKBT51` SPI/pin macros undefined).
 - work: installed dfu-util to provide dfu-suffix; `qmk compile -kb keychron/q1_pro -km default` now succeeds, but `make keychron/q1_pro:renode` still fails (Renode not installed).
+- work: yamllint missing; installed via pip to lint GitHub workflow.
+- work: act CLI unavailable via apt; unable to rerun GitHub Actions locally.


### PR DESCRIPTION
## Summary
- grant labeler workflow labels: write permission so it can apply tags
- document missing yamllint and act tooling

## Testing
- `yamllint .github/workflows/labeler.yml`
- `yamllint .github/labeler.yml` *(fails: indentation warnings)*
- `act --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aada516fec8324975f87bb930c850f