### PR TITLE
docs: note renode package unavailable

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -225,3 +225,5 @@ typedef struct {
 - work: installed dfu-util to provide dfu-suffix; `qmk compile -kb keychron/q1_pro -km default` now succeeds, but `make keychron/q1_pro:renode` still fails (Renode not installed).
 - work: yamllint missing; installed via pip to lint GitHub workflow.
 - work: act CLI unavailable via apt; unable to rerun GitHub Actions locally.
+
+- work: renode package unavailable via apt; make keychron/q1_pro:renode fails (renode: not found).


### PR DESCRIPTION
## Summary
- note renode apt package unavailable; make keychron/q1_pro:renode fails without renode executable

## Testing
- `make keychron/q1_pro:renode` *(fails: renode: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aadc08caa08324986ff46283f5c491