### PR TITLE
work: add Keychron Q1 Pro TinyGo target

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -64,3 +64,4 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: set Makefile tinygo target to local board file and added requirements-dev.txt.
 
 - work: prefixed GitHub Action workflow names with go/main label.
+- work: added Keychron Q1 Pro TinyGo target file.

--- a/board/keychron_q1_pro.json
+++ b/board/keychron_q1_pro.json
@@ -1,0 +1,12 @@
+{
+    "inherits": ["cortex-m4"],
+    "build-tags": ["keychron_q1_pro", "stm32l432", "stm32l4x2", "stm32l4", "stm32"],
+    "serial": "usb",
+    "linkerscript": "targets/stm32l4x2.ld",
+    "extra-files": [
+        "src/device/stm32/stm32l4x2.s"
+    ],
+    "flash-method": "openocd",
+    "openocd-interface": "stlink-v2-1",
+    "openocd-target": "stm32l4x"
+}

--- a/cmd/firmware/main.go
+++ b/cmd/firmware/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/qmk/qmk_firmware/board/keychron_q1_pro"
+
+func main() {
+	keychron_q1_pro.Init()
+	for {
+	}
+}


### PR DESCRIPTION
## Summary
- add Keychron Q1 Pro board target file
- stub firmware using board initialization
- record addition in CRUSH notes

## Testing
- `go fmt ./...`
- `go test ./...`
- `RENODE=/root/renode/renode RENODE_LOG=hid.log scripts/run-renode.sh` *(fails: ambiguous device/stm32 import)*

------
https://chatgpt.com/codex/tasks/task_e_68aae95bee088324b8037f2ce4066839