### PR TITLE
work: add Keychron Q1 Pro TinyGo target

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -64,3 +64,6 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: set Makefile tinygo target to local board file and added requirements-dev.txt.
 
 - work: prefixed GitHub Action workflow names with go/main label.
+- work: added Keychron Q1 Pro TinyGo target file.
+- work: ensured run-renode script exports GOROOT and namespaced local device/runtime packages.
+- work: defined STM32L432 peripheral pin constants to resolve TinyGo build errors.

--- a/board/keychron_q1_pro.json
+++ b/board/keychron_q1_pro.json
@@ -1,0 +1,12 @@
+{
+    "inherits": ["cortex-m4"],
+    "build-tags": ["keychron_q1_pro", "stm32l432", "stm32l4x2", "stm32l4", "stm32"],
+    "serial": "usb",
+    "linkerscript": "targets/stm32l4x2.ld",
+    "extra-files": [
+        "src/device/stm32/stm32l4x2.s"
+    ],
+    "flash-method": "openocd",
+    "openocd-interface": "stlink-v2-1",
+    "openocd-target": "stm32l4x"
+}

--- a/board/keychron_q1_pro/board.go
+++ b/board/keychron_q1_pro/board.go
@@ -1,7 +1,7 @@
 package keychron_q1_pro
 
 import (
-	"device/stm32"
+	"github.com/qmk/qmk_firmware/device/stm32"
 	"github.com/qmk/qmk_firmware/machine"
 )
 

--- a/cmd/firmware/main.go
+++ b/cmd/firmware/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/qmk/qmk_firmware/board/keychron_q1_pro"
+
+func main() {
+	keychron_q1_pro.Init()
+	for {
+	}
+}

--- a/device/stm32/go.mod
+++ b/device/stm32/go.mod
@@ -1,7 +1,7 @@
-module device/stm32
+module github.com/qmk/qmk_firmware/device/stm32
 
 go 1.24.3
 
-require runtime/volatile v0.0.0
+require github.com/qmk/qmk_firmware/runtime/volatile v0.0.0
 
-replace runtime/volatile => ../../runtime/volatile
+replace github.com/qmk/qmk_firmware/runtime/volatile => ../../runtime/volatile

--- a/device/stm32/stm32l432.go
+++ b/device/stm32/stm32l432.go
@@ -1,6 +1,6 @@
 package stm32
 
-import "runtime/volatile"
+import "github.com/qmk/qmk_firmware/runtime/volatile"
 
 type GPIO_Type struct {
 	MODER  volatile.Register32

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,10 @@ module github.com/qmk/qmk_firmware
 
 go 1.24.3
 
-require (
-    device/stm32 v0.0.0
-    runtime/volatile v0.0.0
-)
+require github.com/qmk/qmk_firmware/device/stm32 v0.0.0
 
-replace device/stm32 => ./device/stm32
-replace runtime/volatile => ./runtime/volatile
+require github.com/qmk/qmk_firmware/runtime/volatile v0.0.0 // indirect
 
+replace github.com/qmk/qmk_firmware/device/stm32 => ./device/stm32
+
+replace github.com/qmk/qmk_firmware/runtime/volatile => ./runtime/volatile

--- a/machine/stm32l432.go
+++ b/machine/stm32l432.go
@@ -1,6 +1,6 @@
 package machine
 
-import "device/stm32"
+import "github.com/qmk/qmk_firmware/device/stm32"
 
 // Basic support for the STM32L432 microcontroller. This file adds minimal
 // definitions for clocks, GPIO, USB, SPI, and I2C peripherals so that TinyGo
@@ -16,12 +16,51 @@ const (
 	portB
 )
 
+// GPIO pin numbers.
 const (
-	PA0 Pin = portA + 0
-	PA1 Pin = portA + 1
-	PA2 Pin = portA + 2
+	PA0  Pin = portA + 0
+	PA1  Pin = portA + 1
+	PA2  Pin = portA + 2
+	PA3  Pin = portA + 3
+	PA4  Pin = portA + 4
+	PA5  Pin = portA + 5
+	PA6  Pin = portA + 6
+	PA7  Pin = portA + 7
+	PA8  Pin = portA + 8
+	PA9  Pin = portA + 9
+	PA10 Pin = portA + 10
+	PA11 Pin = portA + 11
+	PA12 Pin = portA + 12
+	PA13 Pin = portA + 13
+	PA14 Pin = portA + 14
+	PA15 Pin = portA + 15
+
 	PB0 Pin = portB + 0
 	PB1 Pin = portB + 1
+	PB2 Pin = portB + 2
+	PB3 Pin = portB + 3
+	PB4 Pin = portB + 4
+	PB5 Pin = portB + 5
+	PB6 Pin = portB + 6
+	PB7 Pin = portB + 7
+	PB8 Pin = portB + 8
+	PB9 Pin = portB + 9
+)
+
+// Default peripheral pin assignments.
+const (
+	// SPI1 pins.
+	SPI0_SCK_PIN = PA5
+	SPI0_SDO_PIN = PA6
+	SPI0_SDI_PIN = PA7
+
+	// I2C1 pins.
+	I2C0_SCL_PIN = PB8
+	I2C0_SDA_PIN = PB9
+
+	// USB FS pins.
+	USBCDC_DM_PIN = PA11
+	USBCDC_DP_PIN = PA12
 )
 
 type PinConfig struct {

--- a/runtime/volatile/go.mod
+++ b/runtime/volatile/go.mod
@@ -1,3 +1,3 @@
-module runtime/volatile
+module github.com/qmk/qmk_firmware/runtime/volatile
 
 go 1.24.3

--- a/scripts/run-renode.sh
+++ b/scripts/run-renode.sh
@@ -10,6 +10,8 @@ if ! command -v "$RENODE" >/dev/null 2>&1; then
   exit 1
 fi
 
+export GOROOT=${GOROOT:-$(go env GOROOT)}
+
 make build
 
 "$RENODE" --disable-xwt \


### PR DESCRIPTION
## Summary
- add Keychron Q1 Pro board target file
- stub firmware using board initialization
- record addition in CRUSH notes
- set GOROOT in Renode script and namespace device/runtime packages
- define STM32L432 pin constants for SPI/I2C/USB defaults

## Testing
- `go fmt ./...`
- `go test ./...`
- `RENODE_LOG=hid.log scripts/run-renode.sh` *(fails: missing /tmp/tinygo/src/crypto)*

------
https://chatgpt.com/codex/tasks/task_e_68aae95bee088324b8037f2ce4066839