### PR TITLE
machine: stub UART and USB serial

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -67,3 +67,4 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: added Keychron Q1 Pro TinyGo target file.
 - work: ensured run-renode script exports GOROOT and namespaced local device/runtime packages.
 - work: defined STM32L432 peripheral pin constants to resolve TinyGo build errors.
+- go/feature-uart: stubbed UART and USB serial interfaces for STM32L432.


### PR DESCRIPTION
## Summary
- add UART pin definitions and serial stubs for STM32L432
- record task note for UART work

## Testing
- `go fmt ./...`
- `go test ./...`
- `make build` *(fails: requires go version 1.18 through 1.22, got go1.24)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53cee480832498103f762e99ab91