### PR TITLE
machine: stub UART and USB serial

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -67,3 +67,5 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: added Keychron Q1 Pro TinyGo target file.
 - work: ensured run-renode script exports GOROOT and namespaced local device/runtime packages.
 - work: defined STM32L432 peripheral pin constants to resolve TinyGo build errors.
+- go/feature-uart: stubbed UART and USB serial interfaces for STM32L432.
+- work: replaced TinyGo machine package to expose STM32L432 peripheral pin constants.

--- a/board/keychron_q1_pro/board.go
+++ b/board/keychron_q1_pro/board.go
@@ -2,7 +2,7 @@ package keychron_q1_pro
 
 import (
 	"github.com/qmk/qmk_firmware/device/stm32"
-	"github.com/qmk/qmk_firmware/machine"
+	"machine"
 )
 
 const (

--- a/docs/api/machine.md
+++ b/docs/api/machine.md
@@ -1,4 +1,4 @@
-package machine // import "github.com/qmk/qmk_firmware/machine"
+package machine // import "machine"
 
 const CPUFrequency = 80_000_000
 type I2C struct{}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,12 @@ go 1.24.3
 
 require github.com/qmk/qmk_firmware/device/stm32 v0.0.0
 
+require machine v0.0.0
+
 require github.com/qmk/qmk_firmware/runtime/volatile v0.0.0 // indirect
 
 replace github.com/qmk/qmk_firmware/device/stm32 => ./device/stm32
 
 replace github.com/qmk/qmk_firmware/runtime/volatile => ./runtime/volatile
+
+replace machine => ./machine

--- a/machine/go.mod
+++ b/machine/go.mod
@@ -1,0 +1,11 @@
+module machine
+
+go 1.24.3
+
+require github.com/qmk/qmk_firmware/device/stm32 v0.0.0
+
+require github.com/qmk/qmk_firmware/runtime/volatile v0.0.0 // indirect
+
+replace github.com/qmk/qmk_firmware/device/stm32 => ../device/stm32
+
+replace github.com/qmk/qmk_firmware/runtime/volatile => ../runtime/volatile

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -5,7 +5,7 @@ package debug
 
 import (
 	"fmt"
-	"github.com/qmk/qmk_firmware/machine"
+	"machine"
 )
 
 // Printf writes formatted debug output to the USB CDC interface.

--- a/pkg/hid/keyboard.go
+++ b/pkg/hid/keyboard.go
@@ -1,8 +1,8 @@
 package hid
 
 import (
-	"github.com/qmk/qmk_firmware/machine"
 	"github.com/qmk/qmk_firmware/pkg/debug"
+	"machine"
 )
 
 // Keycode represents a USB HID key usage ID.

--- a/pkg/matrix/matrix.go
+++ b/pkg/matrix/matrix.go
@@ -3,9 +3,9 @@ package matrix
 import (
 	"time"
 
-	"github.com/qmk/qmk_firmware/machine"
 	"github.com/qmk/qmk_firmware/pkg/debug"
 	"github.com/qmk/qmk_firmware/pkg/power"
+	"machine"
 )
 
 // Pin abstracts a GPIO pin for scanning.

--- a/pkg/matrix/matrix_test.go
+++ b/pkg/matrix/matrix_test.go
@@ -3,9 +3,9 @@ package matrix
 import (
 	"testing"
 
-	"github.com/qmk/qmk_firmware/machine"
 	"github.com/qmk/qmk_firmware/pkg/power"
 	"github.com/qmk/qmk_firmware/pkg/rgb"
+	"machine"
 )
 
 type testPin struct {


### PR DESCRIPTION
## Summary
- replace TinyGo's machine package with local module exposing STM32L432 pin constants
- update board and packages to import standard machine path

## Testing
- `go fmt ./...`
- `(cd machine && go fmt ./...)`
- `go test ./...`
- `(cd machine && go test ./...)`
- `make build` *(fails: requires go version 1.18 through 1.22, got go1.24)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53cee480832498103f762e99ab91