### PR TITLE
Fix Renode platform description

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -73,3 +73,4 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: installed TinyGo 0.39.0 and make build fails: undefined peripheral pin constants in std machine package.
 - work: added minimal machine stubs and Makefile copy step to fix TinyGo build.
 - work: staged TinyGo root locally during build to avoid system writes.
+- work: fixed Renode platform description syntax to load in simulator.

--- a/renode/stm32l432_keyboard.repl
+++ b/renode/stm32l432_keyboard.repl
@@ -1,5 +1,3 @@
-using sysbus
-
 name: "stm32l432-keyboard"
 
 cpu: CPU.STM32L432 @ sysbus


### PR DESCRIPTION
## Summary
- fix Renode platform description to load without syntax error
- document fix in task notes

## Testing
- `go fmt ./...`
- `go test ./...`
- `scripts/run-renode.sh` *(fails: renode command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab657d599c83248c31c488f9eceb1b