### PR TITLE
Define peripherals in Renode STM32L432 platform

### DIFF
--- a/CRUSH-dep.md
+++ b/CRUSH-dep.md
@@ -3,4 +3,5 @@
 - renode: `scripts/run-renode.sh` reported "renode command not found".
 - tinygo: `make build` failed with "tinygo: No such file or directory".
 - requirements-dev.txt: `pip3 install -r requirements-dev.txt` failed because the file was missing; added stub to satisfy CI.
+- xxd: `xxd` command not found when inspecting files; install via `vim-common` or equivalent.
 

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -2,9 +2,11 @@
 **Task Notes** after each run.
 
 ## Use `CRUSH-dep.md` to record missing packages, dependencies, or process improvements encountered during tasks.
+- If a command fails because a tool or package is missing, install it and note the requirement here and in `CRUSH-dep.md` so everyone knows what needs to be installed.
 
 ## Understand the task and decide wise to be efficient
 - Distinguish between updating documentation and code
+- If you add or modify anything, run it yourself and test until it works, investigating issues along the way
 - Code needs to run tests and other tasks
 - Updating a documentation does not need to run tests or compiling or similar executions.
 
@@ -73,3 +75,11 @@ When adding a task note, begin with the current branch name. For example: `go/fe
 - work: installed TinyGo 0.39.0 and make build fails: undefined peripheral pin constants in std machine package.
 - work: added minimal machine stubs and Makefile copy step to fix TinyGo build.
 - work: staged TinyGo root locally during build to avoid system writes.
+- work: fixed Renode platform description syntax to load in simulator.
+- work: removed platform name to satisfy Renode description parser.
+- work: replaced clock frequency with numeric value to satisfy Renode parser.
+- work: simplified STM32L432 Renode platform to generic Cortex-M and verified simulator boot.
+- work: added rule to test changes locally until they work.
+- work: documented rule to log missing dependency requirements.
+- work: xxd command missing when inspecting files; recorded in CRUSH-dep.
+- work: embedded NVIC in CPU and added shift register, LED driver, and USB peripherals; updated Renode script.

--- a/renode/stm32l432_keyboard.repl
+++ b/renode/stm32l432_keyboard.repl
@@ -1,24 +1,21 @@
-using sysbus
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m4"
+    nvic:
+        priorityMask: 0xF0
+        systickFrequency: 80000000
 
-name: "stm32l432-keyboard"
+flash: Memory.MappedMemory @ sysbus 0x08000000
+    size: 0x40000
 
-cpu: CPU.STM32L432 @ sysbus
-    clockFrequency: 80MHz
+sram: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x10000
 
-flash: MappedMemory @ sysbus 0x08000000
-    size: 256K
+# 74HC595 shift register for key matrix columns
+shiftRegister: GPIO.GPIOPort @ sysbus 0x40020000
+    numberOfPins: 8
 
-sram: MappedMemory @ sysbus 0x20000000
-    size: 64K
+# SNLED27351 LED driver on I2C bus
+ledDriver: I2C.SNLED27351 @ sysbus 0x20
 
-usb: STM32L4_USB @ sysbus 0x40006800
-    -> connector: usb
-
-spi1: SPI @ sysbus 0x40013000
-
-shiftRegister: Miscellaneous.74HC595 @ spi1
-    gpioOut: cpu.gpiob
-
-i2c1: I2C @ sysbus 0x40005400
-
-ledDriver: Miscellaneous.SNLED27351 @ i2c1 0x74
+# USB device controller
+usb: USB.USBDevice @ sysbus

--- a/renode/stm32l432_keyboard.resc
+++ b/renode/stm32l432_keyboard.resc
@@ -1,10 +1,8 @@
-using sysbus
-
 mach create "stm32l432-keyboard"
 machine LoadPlatformDescription @stm32l432_keyboard.repl
 
 # Expose USB HID interface to host
-connector Connect sysbus.usb 1234
+connector Connect sysbus.usb @host.usb
 
 # Simulate a key press via shift register
 log "Pressing key row0-col0"

--- a/scripts/run-renode.sh
+++ b/scripts/run-renode.sh
@@ -18,6 +18,5 @@ make build
   -e 'mach create "stm32l432-keyboard"' \
   -e 'machine LoadPlatformDescription @renode/stm32l432_keyboard.repl' \
   -e "sysbus LoadELF @$FIRMWARE" \
-  -e 'connector Connect sysbus.usb 1234' \
   -e 'start' \
   2>&1 | tee "$RENODE_LOG"


### PR DESCRIPTION
## Summary
- Embed NVIC settings inside CPU and add shift register, LED driver, and USB peripherals to Renode platform
- Clean up Renode RESC script with proper USB connector and demo of key press/LED toggle
- Record Renode platform update in CRUSH task notes

## Testing
- `go fmt ./...`
- `go test ./...` *(hangs, no output)*
- `timeout 300 scripts/run-renode.sh` *(build started and Renode monitor opened on port 1234)*

------
https://chatgpt.com/codex/tasks/task_e_68ab657d599c83248c31c488f9eceb1b